### PR TITLE
Request to myft should use MYFT_API_KEY

### DIFF
--- a/lib/helpers/config.js
+++ b/lib/helpers/config.js
@@ -11,7 +11,7 @@ const config = {
     retry: parseInt((envVars.MAX_RETRIES || 5), 10)
   },
   MYFT_API_URL: envVars.KAT_MYFT_API_URL || envVars.MYFT_API_URL,
-  MYFT_API_KEY: envVars.KAT_MYFT_API_KEY || envVars.MYFT_API_KEY,
+  MYFT_API_KEY: envVars.MYFT_API_KEY,
   ACS_API_URL: envVars.KAT_ACS_API_URL || envVars.ACS_API_URL,
   ACS_API_KEY: envVars.KAT_ACS_API_KEY || envVars.ACS_API_KEY,
   API_GATEWAY_HOST: envVars.KAT_API_GATEWAY_HOST || envVars.API_GATEWAY_HOST,


### PR DESCRIPTION
Use the shared MYFT_API_KEY value for myft-api request rather than KAT_MYFT_API
 🐿 v2.5.16