### PR TITLE
Fixes call to next-myft-api for removing user followers

### DIFF
--- a/lib/myFTClient.js
+++ b/lib/myFTClient.js
@@ -383,12 +383,11 @@ function _addRemoveRelationships (method, node, nodeId, rel, relType, relIds, re
   return _createAndTriggerRelationshipRequest(method, node, nodeId, rel, relType, undefined, body, params);
 }
 
-
-  /**
+/**
  * Add/Remove relationships v3/kat/ to/from node
  * @param {String} method - Expects POST or DELETE
  * @param {String} node -
- * @param {String} nodeId -
+ * @param {String|Array} nodeId - a single or array of user/group IDs we are removing the KAT follow relationship for.
  * @param {String|Object|Array} relIds -a single node uuid, object with rel data or array of node uuids
  * @param {Object} [relProp] -
  * @param {Boolean} [memberFollows] - denotes if this is for group members or not
@@ -404,12 +403,7 @@ function _addRemoveKatRelationships (method, node, nodeId, relIds, relProp, memb
     options
   );
 
-  let nodeIdArray = [];
-  if (Array.isArray(nodeId)){
-    nodeIdArray = nodeId.slice();
-  } else {
-    nodeIdArray.push(nodeId);
-  }
+  const nodeIdArray = Array.isArray(nodeId) ? nodeId : [nodeId];
 
   let subjects;
   if (Array.isArray(relIds)) {

--- a/lib/myFTClient.js
+++ b/lib/myFTClient.js
@@ -404,6 +404,13 @@ function _addRemoveKatRelationships (method, node, nodeId, relIds, relProp, memb
     options
   );
 
+  let nodeIdArray = [];
+  if (Array.isArray(nodeId)){
+    nodeIdArray = nodeId.slice();
+  } else {
+    nodeIdArray.push(nodeId);
+  }
+
   let subjects;
   if (Array.isArray(relIds)) {
     subjects = relIds.map(data => {
@@ -422,7 +429,7 @@ function _addRemoveKatRelationships (method, node, nodeId, relIds, relProp, memb
   }
 
   const body = {
-    ids: nodeId,
+    ids: nodeIdArray,
     subjects: subjects
   };
 

--- a/test/myFTClient.spec.js
+++ b/test/myFTClient.spec.js
@@ -917,16 +917,17 @@ describe('myFT Client proxy', () => {
           .catch(done);
       });
 
-      it('Should remove concept(s) followed by a user', done => {
+      it('Should remove concept(s) followed by a single user', done => {
+        const userId = '00000000-0000-0000-0000-000000000002';
         nock(baseUrl)
           .delete('/kat/user/follows',{
-            ids: ids,
+            ids: [userId], // The next-myft-api expects an array of user IDs
             subjects: subjects
           })
           .query(true)
           .reply(204, () => ({}));
 
-        myFT.removeConceptsFollowedByKatUser(ids, subjects)
+        myFT.removeConceptsFollowedByKatUser(userId, subjects)
           .then(addResp => {
             expect(addResp).to.be.an('Object');
             expect(addResp.status).to.equal(204);
@@ -937,7 +938,6 @@ describe('myFT Client proxy', () => {
       });
 
       it('Should remove concept(s) followed by a group', done => {
-
           nock(baseUrl)
             .delete('/kat/group/follows')
             .query(true)


### PR DESCRIPTION
Now converts ids to an array, if not already, before calling next-myft-api endpoint for removing user follows

 🐿 v2.5.16