### PR TITLE
add error handling to acx call

### DIFF
--- a/lib/acquisitionCtxClient.js
+++ b/lib/acquisitionCtxClient.js
@@ -22,10 +22,25 @@ function getContexts (ctxFilter) {
 
 	const url = `${config.API_GATEWAY_HOST}/acquisition-contexts/v1${queryString}`;
 	return fetch(url, Object.assign({}, options))
-		.then(res => helpers.parseJsonRes(res, `${operation} ${queryString}`))
+		.then((res) => {
+			if(res.status !== 200) {
+				const err =  new Error(res.statusText);
+				err.status = res.status;
+				throw err;
+			}
+
+			return helpers.parseJsonRes(res, `${operation} ${queryString}`);
+		})
 		.then(res => {
 			log.debug({operation, queryString, res: 'success'});
 			return res.AcquisitionContext;
+		})
+		.catch( (err) => {
+			log.error({operation, queryString, err:err.status}, err);
+			if (err.status === 404) {
+				return null;
+			}
+			throw err;
 		});
 }
 

--- a/lib/acquisitionCtxClient.js
+++ b/lib/acquisitionCtxClient.js
@@ -24,7 +24,7 @@ function getContexts (ctxFilter) {
 	return fetch(url, Object.assign({}, options))
 		.then((res) => {
 			if(res.status !== 200) {
-				const err =  new Error(res.statusText);
+				const err = new Error(res.statusText);
 				err.status = res.status;
 				throw err;
 			}


### PR DESCRIPTION
 🐿 v2.6.0 - Fix to overview blowing up if an acquisition context does not exist for a given licence due to unhandled error. 