### PR TITLE
Fix Neo4j Bad Data Errors

### DIFF
--- a/lib/myFTClient.js
+++ b/lib/myFTClient.js
@@ -1177,14 +1177,15 @@ function addConceptsFollowedByKatGroupMembers (groupUUID, conceptUUIDs, relation
 
 /**
  * Add topics for specific group members to follow
- * @param {String|Array} groupUUID - uuid of the group
  * @param {String|Array} userUUIDs - uuids of the group users
- * @param {String|Array} conceptUUIDs - uuid of the topic, or an array of topic uuids, to follow
+ * @param {Array} concepts - Array of objects containing data about the topics to follow
  * @param {Object} relationshipProperties - properties to add to the 'member' relationship(s)
+ * @param {String|Array} groupUUID - uuid of the group
  * @return {Promise} response -
 **/
-function addConceptsFollowedByKatGroupMembSpec (userUUIDs, conceptUUIDs, relationshipProperties, groupUUID) {
-	return _addRemoveKatConceptsFollowed('POST', myftConst.groupNodeName , userUUIDs, conceptUUIDs, relationshipProperties, true, groupUUID);
+function addConceptsFollowedByKatGroupMembSpec (userUUIDs, concepts, relationshipProperties, groupUUID) {
+	const conceptsStrippedBack = concepts.map(concept => ({uuid: concept.uuid, name: concept.name}));
+	return _addRemoveKatConceptsFollowed('POST', myftConst.groupNodeName, userUUIDs, conceptsStrippedBack, relationshipProperties, true, groupUUID);
 }
 
 //TODO Depreciate in v2.0.0
@@ -1193,7 +1194,7 @@ function addConceptsFollowedByKatGroupMembSpec (userUUIDs, conceptUUIDs, relatio
  * @param {String} groupUUID - uuid of the user
  * @param {String|Array} conceptUUIDs - uuid of the topic, or an array of topic uuids, to follow
  * @return {Promise} response -
-**/
+ **/
 function removeConceptsFollowedByGroup (groupUUID, conceptUUIDs) {
 	return _removeConceptsFollowedByNode(myftConst.groupNodeName, groupUUID, conceptUUIDs, true);
 }


### PR DESCRIPTION
We were receiving a `neo4j.ClientError: [Neo.ClientError.Statement.TypeError] Property values can only be of primitive types or arrays thereof` error from Neo4j when adding specific users as following concepts as a result of being a member of a group.

This PR fixes this by stripping back the concept data we send to `next-myft-api` to only contain the concept uuid and name.

 🐿 v2.8.0